### PR TITLE
Load style with import.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # vue-web-request-mediator ChangeLog
 
+### Changed
+- **BREAKING**: Load `main.less` with `import`. Usage of this package requires
+  a suitable build system that can handle imported `less` files.
+
 ## 2.2.1 - 2019-10-08
 
 ### Fixed

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@
  */
 'use strict';
 
+import './main.less';
+
 export {getWebAppManifestIcon} from './manifest.js';
 
 export function install(Vue, options) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "2.2.2-0",
   "description": "Vue Web Request Mediator Components",
   "main": "index.js",
-  "less": "main.less",
   "peerDependencies": {
     "vue": "^2.5.16"
   },


### PR DESCRIPTION
Load `main.less` with `import`. Usage of this package requires a
suitable build system that can handle imported `less` files.